### PR TITLE
[CIRCLE-24306] Fix install command error that happens with older curl versions

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -52,7 +52,7 @@ steps:
             if [ -n "$(curl --help | grep '\-\-http1.1')" ]; then
               HTTP1_1_OPTION="--http1.1"
             fi
-            curl -fLSs "$HTTP1_1_OPTION" https://circle.ci/cli | $SUDO bash
+            curl -fLSs $HTTP1_1_OPTION https://circle.ci/cli | $SUDO bash
             echo "CircleCI CLI version $(circleci --skip-update-check version) has been installed to $(which circleci)"
           fi
         fi

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -48,7 +48,7 @@ steps:
           else
             echo "A different version of the CircleCI CLI is installed ($(circleci version)); updating it"
             $SUDO rm -f "$(which circleci)"
-            curl -fLSs https://circle.ci/cli | $SUDO bash
+            curl -fLSs --http1.1 https://circle.ci/cli | $SUDO bash
             echo "CircleCI CLI version $(circleci --skip-update-check version) has been installed to $(which circleci)"
           fi
         fi

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -52,7 +52,7 @@ steps:
             if [ -n "$(curl --help | grep '\-\-http1.1')" ]; then
               HTTP1_1_OPTION="--http1.1"
             fi
-            curl -fLSs $HTTP1_1_OPTION https://circle.ci/cli | $SUDO bash
+            curl -fLSs "$HTTP1_1_OPTION" https://circle.ci/cli | $SUDO bash
             echo "CircleCI CLI version $(circleci --skip-update-check version) has been installed to $(which circleci)"
           fi
         fi

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -48,7 +48,11 @@ steps:
           else
             echo "A different version of the CircleCI CLI is installed ($(circleci version)); updating it"
             $SUDO rm -f "$(which circleci)"
-            curl -fLSs --http1.1 https://circle.ci/cli | $SUDO bash
+            HTTP1_1_OPTION=""
+            if [ -n "$(curl --help | grep '\-\-http1.1')" ]; then
+              HTTP1_1_OPTION="--http1.1"
+            fi
+            curl -fLSs $HTTP1_1_OPTION https://circle.ci/cli | $SUDO bash
             echo "CircleCI CLI version $(circleci --skip-update-check version) has been installed to $(which circleci)"
           fi
         fi


### PR DESCRIPTION
## Problem
The `curl` command used by this orb's `install` command has started failing in some older versions of `curl` (e.g. `curl 7.54.0 (x86_64-apple-darwin18.0)`) likely due to recent underlying changes in the web server for https://circle.ci/cli such that it now performs redirection with HTTP/2.  The error message shown by `curl` is `curl: (16) Error in the HTTP2 framing layer`. 

Example of job that encountered the error: https://circleci.com/gh/CircleCI-Public/circleci-cli-orb/102

Based on tests, newer versions of `curl` do not have this issue (e.g. `curl 7.68.0 (x86_64-apple-darwin18.7.0)`)

## Code changes
This fix makes use of the `--http1.1` option in `curl` to prevent usage of HTTP/2, and omits the option for versions of `curl` that do not support the `--http1.1` option, like `curl 7.29.0 (x86_64-redhat-linux-gnu)`. 

Versions of `curl` that do not support `--http1.1` likely do not default to HTTP/2 anyway, and hence should be not affected by this issue.

## Tests
Example of job that previously failed but now succeeds with fix applied: https://circleci.com/gh/CircleCI-Public/circleci-cli-orb/147
Example of job with fix applied, that skips `--http1.1` because the version of `curl` doesn't support it: https://circleci.com/gh/CircleCI-Public/circleci-cli-orb/152