### PR TITLE
Replace shorturl with direct link to github [semver:patch]

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -45,11 +45,7 @@ steps:
           else
             echo "A different version of the CircleCI CLI is installed ($(circleci version)); updating it"
             $SUDO rm -f "$(which circleci)"
-            HTTP1_1_OPTION=""
-            if [ -n "$(curl --help | grep '\-\-http1.1')" ]; then
-              HTTP1_1_OPTION="--http1.1"
-            fi
-            curl -fLSs $HTTP1_1_OPTION https://circle.ci/cli | $SUDO bash
+            curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | $SUDO bash
             echo "CircleCI CLI version $(circleci --skip-update-check version) has been installed to $(which circleci)"
           fi
         fi


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

When installing the CLI via the orb it had used a short URL where the SSL connection would fail with the following error

`curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to circle.ci:443`

This removes the endpoint where the SSL connection would fail and removes any issues with the redirect in curl version ~7.58

### Description

see title - I also removed the http1.1 flag since we don't need to worry about connecting to github - please let me know if you think we need it, but 100 iterations and I had no failure from the following misuse of http2

```
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=www.github.com
*  start date: May  6 00:00:00 2020 GMT
*  expire date: Apr 14 12:00:00 2022 GMT
*  subjectAltName: host "raw.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=DigiCert SHA2 High Assurance Server CA
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
} [5 bytes data]
* Using Stream ID: 1 (easy handle 0x565224f9dea0)
} [5 bytes data]
> GET /CircleCI-Public/circleci-cli/master/install.sh HTTP/1.1
> Host: raw.githubusercontent.com
> User-Agent: curl/7.52.1
> Accept: */*
> 
```

When using a newer version of curl, the request is http2 and works just fine

```
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=www.github.com
*  start date: May  6 00:00:00 2020 GMT
*  expire date: Apr 14 12:00:00 2022 GMT
*  subjectAltName: host "raw.githubusercontent.com" matched cert's "*.githubusercontent.com"
*  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=DigiCert SHA2 High Assurance Server CA
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x558a2d637df0)
> GET /CircleCI-Public/circleci-cli/master/install.sh HTTP/2
> Host: raw.githubusercontent.com
> user-agent: curl/7.68.0
> accept: */*
```
