### PR TITLE
Make it possible to install desired version

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -45,7 +45,8 @@ steps:
           else
             echo "A different version of the CircleCI CLI is installed ($(circleci version)); updating it"
             $SUDO rm -f "$(which circleci)"
-            curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | $SUDO bash
+            VERSION_WO_PREFIX=$(echo $CIRCLECI_CLI_VERSION | cut -d "v" -f 2)
+            curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | $SUDO VERSION=$VERSION_WO_PREFIX bash
             echo "CircleCI CLI version $(circleci --skip-update-check version) has been installed to $(which circleci)"
           fi
         fi


### PR DESCRIPTION

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

[Wrong version installed](https://app.circleci.com/pipelines/github/streetteam/root/140451/workflows/ee3666cf-294e-4322-aa6a-793d6088da94/jobs/1968362), despite providing other version

![image](https://user-images.githubusercontent.com/36153295/140734161-e4c1c4a8-d0bf-4eae-a2ba-f3bd01b7e069.png)

### Description

[install.sh](https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh) expects `$VERSION` var, not `$CIRCLECI_CLI_VERSION`
