### PR TITLE
feat(executors): add `resource_class` overrides

### DIFF
--- a/src/examples/executor-resource-class-override.yml
+++ b/src/examples/executor-resource-class-override.yml
@@ -1,0 +1,15 @@
+description: Override the default resource_class for the executor
+
+usage:
+  version: 2.1
+
+  orbs:
+    cli: circleci/circleci-cli@x.y.z
+
+  jobs:
+    use-executor:
+      executor:
+        name: cli/default
+        resource_class: medium
+      steps:
+        - run: echo "this job is using the orb's default executor"

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -8,6 +8,12 @@ parameters:
     description: >
       What version of the CircleCI CLI Docker image? For full list, see
       https://hub.docker.com/r/circleci/circleci-cli/tags
+  resource_class:
+    type: enum
+    default: "small"
+    description: resource_class to use for the executor
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
 
 docker:
   - image: circleci/circleci-cli:<<parameters.tag>>
+resource_class: << parameters.resource_class >>


### PR DESCRIPTION


### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues
In many orgs, the default is now to use large executors, which costs more money, and is almost always going to be overkill for typical uses of this orb.

### Description
- Add ability to override the `resource_class` for the executor
- Default the executor `resource_class` to "small", which should be sufficient for most uses of this orb