### PR TITLE
Fix Install Job Script

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -19,13 +19,14 @@ fi
 # check if CircleCI CLI needs to be installed
 
 if command -v circleci > "$OUTPUT" 2>&1; then
-    if circleci version | grep "${CIRCLECI_CLI_VERSION:1}" > /dev/null 2>&1; then
+    VERSION="${CIRCLECI_CLI_VERSION:1}"
+    if circleci version | grep "${VERSION}" > /dev/null 2>&1; then
         echo "circleci $CIRCLECI_CLI_VERSION is already installed"
         exit 0
     else
         echo "A different version of the CircleCI CLI is installed ($(circleci version)); updating it"
         $SUDO rm -f "$(which circleci)"
-        curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | $SUDO bash
+        curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | $SUDO VERSION="$VERSION" bash
         echo "CircleCI CLI version $(circleci --skip-update-check version) has been installed to $(which circleci)"
     fi
 fi


### PR DESCRIPTION
### Motivation, issues

Fixes #13 - Version is not being passed to the public install script (ref [here](https://github.com/CircleCI-Public/circleci-cli/blob/develop/install.sh#L20) ). Without the variable set the install script always installs the latest.

### Description

Update orb install script to pass version to public install script
